### PR TITLE
Use linux rather than manylinux or musllinux in tag

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -64,7 +64,13 @@ class WhisperCppBuildHook(BuildHookInterface):
 
         from packaging.tags import sys_tags
 
-        tag = next(sys_tags())
+        tag = next(
+            iter(
+                tag
+                for tag in sys_tags()
+                if "manylinux" not in tag.platform and "musllinux" not in tag.platform
+            )
+        )
         tag_platform = tag.platform
 
         # On macOS, set the version based on `MACOSX_DEPLOYMENT_TARGET`.


### PR DESCRIPTION
cibuildwheel will audit the wheel and add the appropriate Linux tags.